### PR TITLE
Add @loader_path to rpaths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ gem-install:
 	bundle install --jobs 4 --retry 3
 
 zip: build
-	install_name_tool -add_rpath $(XCODE_DEFAULT_TOOLCHAIN)/usr/lib/swift/macosx $(TOOL_BIN) 2>/dev/null || true
+	install_name_tool -add_rpath @loader_path -add_rpath $(XCODE_DEFAULT_TOOLCHAIN)/usr/lib/swift/macosx $(TOOL_BIN) 2>/dev/null || true
 	rm -f $(TOOL_NAME).zip
 	zip -j $(TOOL_NAME).zip $(TOOL_BIN) $(TOOL_BIN_DIR)/lib_InternalSwiftSyntaxParser.dylib LICENSE
 


### PR DESCRIPTION
## Checklist

- [x] All tests are passed.
- [ ] Added tests.
- [x] Searched existing issues to make sure not duplicated.

## Motivation and Context
This makes the tool searchs for lib_InternalSwiftSyntaxParser.dylib in
the current directory first.