### PR TITLE
CI: Publish on macos-14

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     name: Publish
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         xcode_version:

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ So you should use swift-mod version that built with compatible version of Swift 
 |5.7          |0.1.1                           |
 |5.8          |0.2.0                           |
 |5.9          |0.2.0                           |
-|5.10         |0.2.1                           |
+|5.10         |0.2.2                           |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ So you should use swift-mod version that built with compatible version of Swift 
 |5.7          |0.1.1                           |
 |5.8          |0.2.0                           |
 |5.9          |0.2.0                           |
-|5.10         |0.2.2                           |
+|5.10         |0.2.1                           |
 
 ---
 


### PR DESCRIPTION
## Checklist

- [ ] All tests are passed.
- [ ] Added tests.
- [ ] Searched existing issues to make sure not duplicated.

## Motivation and Context

Publish work fails with no Xcode 15.4 available in 13 runners. 

## Related Issue

Regressed in https://github.com/ra1028/swift-mod/pull/25

## Impact on Existing Code

